### PR TITLE
fix: #3 Missing Image

### DIFF
--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -30,7 +30,7 @@ class Item extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.onUnload(); 
+    this.props.onUnload();
   }
 
   render() {
@@ -50,7 +50,10 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image || window.location.origin + '/placeholder.png'}
+                src={
+                  this.props.item.image ||
+                  window.location.origin + "/placeholder.png"
+                }
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -30,7 +30,7 @@ class Item extends React.Component {
   }
 
   componentWillUnmount() {
-    this.props.onUnload();
+    this.props.onUnload(); 
   }
 
   render() {

--- a/frontend/src/components/Item/index.js
+++ b/frontend/src/components/Item/index.js
@@ -50,7 +50,7 @@ class Item extends React.Component {
           <div className="row bg-white p-4">
             <div className="col-6">
               <img
-                src={this.props.item.image}
+                src={this.props.item.image || window.location.origin + '/placeholder.png'}
                 alt={this.props.item.title}
                 className="item-img"
                 style={{ height: "500px", width: "100%", borderRadius: "6px" }}

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image || window.location.origin + '/placeholder.png'}
+        src={item.image || window.location.origin + "/placeholder.png"}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />

--- a/frontend/src/components/ItemPreview.js
+++ b/frontend/src/components/ItemPreview.js
@@ -36,7 +36,7 @@ const ItemPreview = (props) => {
     >
       <img
         alt="item"
-        src={item.image}
+        src={item.image || window.location.origin + '/placeholder.png'}
         className="card-img-top item-img"
         style={{ borderRadius: "20px" }}
       />


### PR DESCRIPTION
# Fix Missing Image

Image was loading with a broken link. It has been fixed by adding in a placeholder image if there is not an image link included when the item is created.
![Original Broken Link](https://user-images.githubusercontent.com/25237271/184863161-37a1cdaf-b3fd-4bdb-88aa-d22d27250779.png)
![Fixed Link with Placeholder and Linked Image](https://user-images.githubusercontent.com/25237271/184863250-85b0e924-d360-498a-8b7b-b9cf298e167a.png)
